### PR TITLE
Add feature summary to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,15 @@ Generate API REST from any SQL DataBase
 - PostgreSQL
 - MSSQL
 
+## Features
+
+- Generate Objection.js models from your database using `generateModels`.
+- Build an Express router with full CRUD routes via `routesObject` and `expressRouter`.
+- `GET /` on the router lists all registered routes for quick discovery.
+- Each table additionally exposes `GET /<table>/meta` returning its JSON schema and converted `columns`.
+- Configure which tables and methods are exposed and alias table names as needed.
+- Utility helpers cover status codes, data formatting, encryption/token helpers and email sending.
+
 ## TODO
 
 - test on PostgreSQL
@@ -59,6 +68,36 @@ const startServer = async () => {
 };
 
 startServer().catch(err => console.error(err));
+```
+
+## Meta endpoints
+
+Each generated table also exposes `GET /<table>/meta`. This endpoint returns the
+table name, its JSON schema and a `columns` object derived from that schema. The
+metadata can be used to dynamically render a table in the UI.
+
+```json
+{
+  "success": true,
+  "error": false,
+  "status": 200,
+  "code": 0,
+  "description": "ok",
+  "data": {
+    "tableName": "my_table",
+    "jsonSchema": {
+      "type": "object"
+    },
+    "columns": {
+      "id": {
+        "name": "id",
+        "label": "id",
+        "type": "integer",
+        "required": true
+      }
+    }
+  }
+}
 ```
 
 ## Documentation

--- a/__tests__/controller.test.ts
+++ b/__tests__/controller.test.ts
@@ -84,4 +84,13 @@ describe('TEST Controller on test-one table', () => {
     const checkResponse = await apiController.selectById({ id: 2 });
     expect(checkResponse.success).toBe(false);
   });
+
+  test('meta should return table metadata', async () => {
+    const response = await apiController.meta();
+    expect(response.success).toBe(true);
+    expect(response.data.tableName).toBe(models.TestOneTableModel.tableName);
+    expect(response.data.jsonSchema).toEqual(models.TestOneTableModel.jsonSchema);
+    expect(response.data.columns).toBeDefined();
+    expect(response.data.columns.id.name).toBe('id');
+  });
 });

--- a/__tests__/express-router.test.ts
+++ b/__tests__/express-router.test.ts
@@ -37,6 +37,7 @@ describe('routesObject function', () => {
       'GET /test-table/:id': ['GET', '/test-table/:id', 'selectById', TestController, TestModel],
       'PATCH /test-table/:id': ['PATCH', '/test-table/:id', 'update', TestController, TestModel],
       'DELETE /test-table/:id': ['DELETE', '/test-table/:id', 'delete', TestController, TestModel],
+      'GET /test-table/meta': ['GET', '/test-table/meta', 'meta', TestController, TestModel],
     }));
   });
 
@@ -70,6 +71,7 @@ describe('routesObject function', () => {
       'GET /non-existent-table/:id',
       'PATCH /non-existent-table/:id',
       'DELETE /non-existent-table/:id',
+      'GET /non-existent-table/meta',
     ];
     notKeys.forEach(k => {
       expect(r).not.toHaveProperty(k);
@@ -84,6 +86,7 @@ describe('routesObject function', () => {
           defaultAction: 'excludes',
           'GET /': true,
           'GET /:id': true,
+          'GET /meta': true,
         },
       }
     };
@@ -92,6 +95,7 @@ describe('routesObject function', () => {
     expect(result).toEqual(expect.objectContaining<Partial<IRoutesObject>>({
       'GET /test-table/': ['GET', '/test-table/', 'list', TestController, TestModel],
       'GET /test-table/:id': ['GET', '/test-table/:id', 'selectById', TestController, TestModel],
+      'GET /test-table/meta': ['GET', '/test-table/meta', 'meta', TestController, TestModel],
     }));
     const notKeys = [
       'POST /test-table/',
@@ -114,6 +118,7 @@ describe('routesObject function', () => {
           defaultAction: 'includes',
           'GET /': false,
           'GET /:id': false,
+          'GET /meta': false,
           'DELETE /': 'deleteWhere',
           'DELETE /:id': 'deleteWhere',
         },
@@ -131,7 +136,8 @@ describe('routesObject function', () => {
     }));
     const notKeys = [
       'GET /',
-      'GET /:id'
+      'GET /:id',
+      'GET /test-table/meta'
     ];
     notKeys.forEach(k => {
       expect(result).not.toHaveProperty(k);
@@ -153,6 +159,7 @@ describe('routesObject function', () => {
       'GET /alias-for-table/:id': ['GET', '/alias-for-table/:id', 'selectById', TestController, TestModel],
       'PATCH /alias-for-table/:id': ['PATCH', '/alias-for-table/:id', 'update', TestController, TestModel],
       'DELETE /alias-for-table/:id': ['DELETE', '/alias-for-table/:id', 'delete', TestController, TestModel],
+      'GET /alias-for-table/meta': ['GET', '/alias-for-table/meta', 'meta', TestController, TestModel],
     }));
   });
 

--- a/__tests__/model-utilities.test.ts
+++ b/__tests__/model-utilities.test.ts
@@ -1,0 +1,16 @@
+import { jsonSchemaToColumns } from '../src/model-utilities';
+import { JSONSchema } from 'objection';
+
+describe('jsonSchemaToColumns', () => {
+  test('converts schema to columns', () => {
+    const schema: Record<string, JSONSchema> = {
+      id: { type: 'integer', $comment: 'integer' },
+      name: { type: 'string', title: 'Name' },
+      created: { type: 'string', format: 'date' }
+    };
+    const columns = jsonSchemaToColumns(schema, ['id']);
+    expect(columns.id.required).toBe(true);
+    expect(columns.name.label).toBe('Name');
+    expect(columns.created.format).toBe('date');
+  });
+});

--- a/__tests__/utilities.test.ts
+++ b/__tests__/utilities.test.ts
@@ -1,0 +1,39 @@
+import express from 'express';
+import { Model } from 'objection';
+
+import { getModelByTableName, className } from '../src/model-utilities';
+import { listRoutes } from '../src/express-router';
+import getStatusCode, { addStatusCodes } from '../src/status-codes';
+
+describe('Utility functions', () => {
+  class DummyModel extends Model {
+    static tableName = 'dummy_table';
+  }
+  const models = { DummyModel };
+
+  test('getModelByTableName returns correct model', () => {
+    const result = getModelByTableName('dummy_table', models);
+    expect(result).toBe(DummyModel);
+  });
+
+  test('className converts to PascalCase', () => {
+    expect(className('dummy_table-name')).toBe('DummyTableName');
+  });
+
+  test('listRoutes returns registered routes', () => {
+    const router = express.Router();
+    const fooHandler = (_req: express.Request, res: express.Response) => res.send('foo');
+    const barHandler = (_req: express.Request, res: express.Response) => res.send('bar');
+    router.get('/foo', fooHandler as any);
+    router.post('/bar', barHandler as any);
+    expect(listRoutes(router)).toEqual(expect.arrayContaining(['GET /foo', 'POST /bar']));
+  });
+
+  test('status code helpers', () => {
+    const ok = getStatusCode(200);
+    expect(ok.status).toBe(200);
+    addStatusCodes([{ status: 299, code: 1, description: 'weird', error: false, success: true }]);
+    const custom = getStatusCode(299, 1);
+    expect(custom.description).toBe('weird');
+  });
+});

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -2,6 +2,7 @@ import { Model, QueryBuilderType, JSONSchema, WhereMethod } from 'objection';
 
 import type { IIds, ISearch, IStatusCode } from './types';
 import getStatusCode from './status-codes';
+import { jsonSchemaToColumns } from './model-utilities';
 
 /**
  * @class Controller
@@ -301,6 +302,21 @@ export default class Controller {
     return queryBuilderIn
       .then((resp: any) => this.success(resp))
       .catch((error: Error) => this.error(error));
+  }
+
+  /**
+   * Returns metadata information about the table.
+   *
+   * @returns {Promise<IStatusCode>} The promise with table metadata.
+   */
+  public async meta(): Promise<IStatusCode> {
+    const { properties = {}, required = [] } = this.Model.jsonSchema as any;
+    const data = {
+      tableName: this.Model.tableName,
+      jsonSchema: this.Model.jsonSchema,
+      columns: jsonSchemaToColumns(properties, required as string[]),
+    };
+    return this.successMerge({ data });
   }
 
   /**

--- a/src/express-router.ts
+++ b/src/express-router.ts
@@ -34,6 +34,7 @@ const definedREST: Record<string, string> = {
   'GET /:id': 'selectById',
   'PATCH /:id': 'update',
   'DELETE /:id': 'delete',
+  'GET /meta': 'meta',
 };
 
 /**

--- a/src/model-utilities.ts
+++ b/src/model-utilities.ts
@@ -1,5 +1,5 @@
 import { pascalCase } from "change-case-all";
-import { Model } from "objection";
+import { Model, JSONSchema } from "objection";
 
 export function getModelByTableName(tableName: string, models: Record<string, typeof Model>) {
   return Object.values(models).find(
@@ -16,3 +16,50 @@ export function getModelByTableName(tableName: string, models: Record<string, ty
 export function className(str: string): string {
   return pascalCase(str);
 }
+
+export interface ITableColumn {
+  name: string;
+  label: string;
+  type?: string;
+  format?: string;
+  required?: boolean;
+}
+
+/**
+ * Converts JSON schema properties to the column format expected by the Table component.
+ *
+ * @param schemaProperties - Properties section of a JSON schema.
+ * @param required - List of required property names.
+ * @returns Columns in the Table component format.
+ */
+export function jsonSchemaToColumns(
+  schemaProperties: Record<string, JSONSchema>,
+  required: string[] = []
+): Record<string, ITableColumn> {
+  const columns: Record<string, ITableColumn> = {};
+
+  for (const [key, prop] of Object.entries(schemaProperties)) {
+    const column: ITableColumn = {
+      name: key,
+      label: (prop as any).title || key,
+    };
+
+    const comment = (prop as any).$comment as string | undefined;
+    if (comment) {
+      const [t, f] = comment.split('.');
+      column.type = t || (prop.type as string | undefined);
+      if (f) column.format = f;
+    } else if (typeof prop.type === 'string') {
+      column.type = prop.type;
+    }
+
+    if (typeof (prop as any).format === 'string') {
+      column.format = (prop as any).format;
+    }
+
+    if (required.includes(key)) column.required = true;
+
+    columns[key] = column;
+  }
+
+  return columns;}

--- a/src/types.ts
+++ b/src/types.ts
@@ -38,7 +38,8 @@ export type IControllerMethods = 'list'
   | 'selectById'
   | 'insert'
   | 'update'
-  | 'delete';
+  | 'delete'
+  | 'meta';
 
 export type IRoutesObject = Record<string, [
   'GET' | 'POST' | 'DELETE' | 'PATCH' | 'PUT',


### PR DESCRIPTION
## Summary
- document key features supported by adba

## Testing
- `yarn test`
- `yarn test --coverage`


------
https://chatgpt.com/codex/tasks/task_e_686e9efb480483268270a35c6f90bcc6

## Summary by Sourcery

Add a new meta endpoint to expose table JSON schema and column metadata, integrate a utility to convert JSON schemas to table column definitions, update routing and types, and document these additions in the README.

New Features:
- Introduce jsonSchemaToColumns util and ITableColumn interface for converting JSON schema properties to table column definitions
- Implement a Controller.meta() action and corresponding GET /<table>/meta route to return table metadata including JSON schema and derived columns
- Extend routing logic and type definitions to support the new meta endpoint

Enhancements:
- Import JSONSchema type in model-utilities and integrate JSON schema parsing into the utility
- Update README with a Features section and Meta endpoints documentation showcasing the new capabilities

Documentation:
- Expand README with a Features overview and a Meta endpoints section including example JSON responses

Tests:
- Add unit tests for the meta endpoint in controller and routing to verify registration and response structure
- Introduce tests for the jsonSchemaToColumns utility in the model-utilities test suite