### PR TITLE
Add hooks for columns meta customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Generate API REST from any SQL DataBase
 - `GET /` on the router lists all registered routes for quick discovery.
 - Each table additionally exposes `GET /<table>/meta` returning its JSON schema and converted `columns`.
 - Configure which tables and methods are exposed and alias table names as needed.
+- Customize generated JSON schema, relations and columns via hooks in `generateModels`.
 - Utility helpers cover status codes, data formatting, encryption/token helpers and email sending.
 
 ## TODO
@@ -68,6 +69,36 @@ const startServer = async () => {
 };
 
 startServer().catch(err => console.error(err));
+```
+
+## Customizing generated models
+
+`generateModels` accepts optional hooks to modify the generated metadata.
+
+```ts
+const models = await generateModels(knexInstance, {
+  squemaFixings: (table, schema) => {
+    if (table === 'users') {
+      return { extra_field: { type: 'string' } };
+    }
+  },
+  relationsFunc: (table, relations) => {
+    if (table === 'users' && models.ProfileTableModel) {
+      relations.profile = {
+        relation: Model.HasOneRelation,
+        modelClass: models.ProfileTableModel,
+        join: { from: 'users.id', to: 'profiles.user_id' }
+      };
+    }
+    return relations;
+  },
+  columnsFunc: (table, columns) => {
+    if (table === 'users') {
+      columns.created_at = { ...columns.created_at, label: 'Created' };
+    }
+    return columns;
+  }
+});
 ```
 
 ## Meta endpoints

--- a/__tests__/create-models.test.ts
+++ b/__tests__/create-models.test.ts
@@ -40,4 +40,21 @@ describe('SQLite Database Tests', () => {
     expect(models.TestOneTableModel.jsonSchema).toEqual(jsonschema);
   });
 
+  test('columns property should convert schema', () => {
+    const { properties = {}, required = [] } = models.TestOneTableModel.jsonSchema as any;
+    const expected = require('../src/model-utilities').jsonSchemaToColumns(properties, required);
+    expect((models.TestOneTableModel as any).columns).toEqual(expected);
+  });
+
+  test('columnsFunc should modify columns', async () => {
+    const custom = await generateModels(knexInstance, {
+      columnsFunc: (table, cols) => {
+        if (table === 'test-one') {
+          cols.id.label = 'identifier';
+        }
+        return cols;
+      }
+    });
+    expect((custom.TestOneTableModel as any).columns.id.label).toBe('identifier');
+  });
 });

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -311,10 +311,16 @@ export default class Controller {
    */
   public async meta(): Promise<IStatusCode> {
     const { properties = {}, required = [] } = this.Model.jsonSchema as any;
+    const columnsGetter = (this.Model as any).columns;
+    const columns =
+      typeof columnsGetter === 'function'
+        ? columnsGetter.call(this.Model)
+        : jsonSchemaToColumns(properties, required as string[]);
+
     const data = {
       tableName: this.Model.tableName,
       jsonSchema: this.Model.jsonSchema,
-      columns: jsonSchemaToColumns(properties, required as string[]),
+      columns,
     };
     return this.successMerge({ data });
   }

--- a/src/generate-mysql-models.ts
+++ b/src/generate-mysql-models.ts
@@ -3,7 +3,7 @@ import { Knex } from 'knex';
 
 import { deepMerge } from 'dbl-utils';
 
-import { className } from './model-utilities';
+import { className, jsonSchemaToColumns, ITableColumn } from './model-utilities';
 import { IGenerateModelsOptions } from './types';
 
 /**
@@ -17,7 +17,7 @@ export async function generateMySQLModels(
   opts: IGenerateModelsOptions = {}
 ): Promise<Record<string, typeof Model>> {
   const models: Record<string, typeof Model> = {};
-  const { relationsFunc, squemaFixings, parseFunc, formatFunc } = opts;
+  const { relationsFunc, squemaFixings, columnsFunc, parseFunc, formatFunc } = opts;
 
   try {
     // Query table and view structures from the database
@@ -121,6 +121,19 @@ export async function generateMySQLModels(
           }
 
           return relations;
+        }
+
+        /**
+         * Columns information derived from the JSON schema.
+         */
+        static get columns(): Record<string, ITableColumn> {
+          const { properties = {}, required = [] } = this.jsonSchema as any;
+          const cols = jsonSchemaToColumns(properties, required as string[]);
+          if (typeof columnsFunc === 'function') {
+            const r = columnsFunc(structureName, cols);
+            if (r) deepMerge(cols, r);
+          }
+          return cols;
         }
 
         /**

--- a/src/generate-postgresql-models.ts
+++ b/src/generate-postgresql-models.ts
@@ -3,7 +3,7 @@ import { Knex } from 'knex';
 
 import { deepMerge } from 'dbl-utils';
 
-import { className } from './model-utilities';
+import { className, jsonSchemaToColumns, ITableColumn } from './model-utilities';
 import { IGenerateModelsOptions } from './types';
 
 /**
@@ -17,7 +17,7 @@ export async function generatePostgreSQLModels(
   opts: IGenerateModelsOptions = {}
 ): Promise<Record<string, typeof Model>> {
   const models: Record<string, typeof Model> = {};
-  const { relationsFunc, squemaFixings, parseFunc, formatFunc } = opts;
+  const { relationsFunc, squemaFixings, columnsFunc, parseFunc, formatFunc } = opts;
 
   try {
     // Query table and view structures from the database
@@ -129,6 +129,19 @@ export async function generatePostgreSQLModels(
           }
 
           return relations;
+        }
+
+        /**
+         * Columns information derived from the JSON schema.
+         */
+        static get columns(): Record<string, ITableColumn> {
+          const { properties = {}, required = [] } = this.jsonSchema as any;
+          const cols = jsonSchemaToColumns(properties, required as string[]);
+          if (typeof columnsFunc === 'function') {
+            const r = columnsFunc(structureName, cols);
+            if (r) deepMerge(cols, r);
+          }
+          return cols;
         }
 
         /**

--- a/src/generate-sqlite-models.ts
+++ b/src/generate-sqlite-models.ts
@@ -3,7 +3,7 @@ import { Knex } from 'knex';
 
 import { deepMerge } from 'dbl-utils';
 
-import { className } from './model-utilities';
+import { className, jsonSchemaToColumns, ITableColumn } from './model-utilities';
 import { IGenerateModelsOptions } from './types';
 
 /**
@@ -17,7 +17,7 @@ export async function generateSQLiteModels(
   opts: IGenerateModelsOptions = {}
 ): Promise<Record<string, typeof Model>> {
   const models: Record<string, typeof Model> = {};
-  const { relationsFunc, squemaFixings, parseFunc, formatFunc } = opts;
+  const { relationsFunc, squemaFixings, columnsFunc, parseFunc, formatFunc } = opts;
 
   try {
     // Query database structures from SQLite
@@ -112,6 +112,19 @@ export async function generateSQLiteModels(
           }
 
           return relations;
+        }
+
+        /**
+         * Columns information derived from the JSON schema.
+         */
+        static get columns(): Record<string, ITableColumn> {
+          const { properties = {}, required = [] } = this.jsonSchema as any;
+          const cols = jsonSchemaToColumns(properties, required as string[]);
+          if (typeof columnsFunc === 'function') {
+            const r = columnsFunc(structureName, cols);
+            if (r) deepMerge(cols, r);
+          }
+          return cols;
         }
 
         /**

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import { JSONSchema, Model, RelationMappings } from "objection";
+import { ITableColumn } from "./model-utilities";
 
 import Controller from "./controller";
 
@@ -75,6 +76,6 @@ export type IIds = {
 export type IGenerateModelsOptions = {
   relationsFunc?: (tableName: string, relations: RelationMappings) => RelationMappings;
   squemaFixings?: (tableName: string, schema: Record<string, JSONSchema>) => Record<string, JSONSchema>;
+  columnsFunc?: (tableName: string, columns: Record<string, ITableColumn>) => Record<string, ITableColumn>;
   parseFunc?: (tableName: string, json: any) => any;
-  formatFunc?: (tableName: string, json: any) => any;
-};
+  formatFunc?: (tableName: string, json: any) => any;};


### PR DESCRIPTION
## Summary
- allow `generateModels` to extend column metadata via new `columnsFunc` hook
- expose model columns and adjust meta() accordingly
- document how to customize schema, relations and columns
- test new columns hook

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_686ead7cce4c83269763a9652ed7418e

## Summary by Sourcery

Introduce a new `columnsFunc` hook in `generateModels` for customizing generated column metadata, expose a static `columns` getter on models and integrate it into the `/meta` endpoint, update the README with customization hook documentation, and add tests for default column conversion and the new hook.

New Features:
- Add `columnsFunc` hook to allow extending or modifying generated column metadata in `generateModels`
- Expose a static `columns` getter on generated models and integrate it into the `/meta` endpoint

Enhancements:
- Update `Controller.meta()` to use the model’s `columns` getter when constructing the meta response

Documentation:
- Document schema, relations, and columns customization hooks in the README

Tests:
- Add tests for default column conversion via `jsonSchemaToColumns`
- Add tests ensuring `columnsFunc` correctly customizes column metadata