### PR TITLE
Add JSON argument parsing

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "main": "dist/cjs/index.js",
   "module": "dist/esm/index.js",
   "types": "dist/types/index.d.ts",
+  "bin": "dist/cjs/cli.js",
   "exports": {
     ".": {
       "import": "./dist/esm/index.js",
@@ -140,7 +141,9 @@
     "tunnel-ssh": "^5.2.0",
     "useragent": "^2.3.0",
     "uuid": "^11.0.2",
-    "zod": "^3.25.67"
+    "zod": "^3.25.67",
+    "dotenv": "^16.3.1",
+    "yargs": "^17.7.2"
   },
   "devDependencies": {
     "@babel/core": "^7.26.0",

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,0 +1,57 @@
+#!/usr/bin/env node
+require('dotenv').config();
+import fs from 'fs';
+import path from 'path';
+import yargs from 'yargs';
+import { hideBin } from 'yargs/helpers';
+import { resolveRefs } from 'dbl-utils';
+import * as pkg from './index';
+
+const cli = yargs(hideBin(process.argv));
+
+function parseInput(value: string): any {
+  if (typeof value !== 'string') return value;
+  let content = value;
+  if (fs.existsSync(value)) {
+    content = fs.readFileSync(value, 'utf8');
+  }
+  try {
+    const json = JSON.parse(content);
+    return resolveRefs(json, { env: process.env } as any);
+  } catch {
+    return value;
+  }
+}
+
+for (const name of Object.keys(pkg)) {
+  const fn: any = (pkg as any)[name];
+  if (typeof fn !== 'function') continue;
+
+  const cmdPath = path.join(__dirname, 'commands', `${name}.js`);
+  if (fs.existsSync(cmdPath)) {
+    const mod = require(cmdPath);
+    const describe = mod.describe || `Run ${name}`;
+    const builder = typeof mod.builder === 'function' ? mod.builder : (y: any) => y;
+    const handler = mod.handler || mod.main;
+    if (typeof handler === 'function') {
+      cli.command(name, describe, builder, handler);
+    }
+  } else {
+    cli.command(
+      name + ' [args..]',
+      `Ejecuta la función ${name}`,
+      y => y.positional('args', { type: 'string', array: true }),
+      async argv => {
+        const raw = (argv.args || []) as any[];
+        const args = raw.map(a => parseInput(a));
+        const result = await Promise.resolve(fn(...args));
+        if (result !== undefined) {
+          if (typeof result === 'string') console.log(result);
+          else console.log(JSON.stringify(result, null, 2));
+        }
+      }
+    );
+  }
+}
+
+cli.demandCommand(1).help().argv;


### PR DESCRIPTION
## Summary
- remove command-specific dumpDatabase file
- add parseInput utility to CLI for JSON or path detection
- support automatic argument parsing with environment variable refs

## Testing
- `yarn install`
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_686edcb747f4832693749eb6691277ba

## Summary by Sourcery

Add a unified CLI wrapper around the library that auto-registers functions as commands, supports JSON or file-based argument input, and resolves environment variable references via dotenv

New Features:
- Expose library functions via a yargs-based CLI with a single executable entrypoint
- Enable JSON argument parsing from either inline strings or file paths and resolve environment variable references

Enhancements:
- Automatically discover and register commands for each exported function, with optional command modules under the commands directory

Build:
- Add dotenv and yargs dependencies and configure the package.json bin field to point to the compiled CLI script