### PR TITLE
Add custom endpoints support to router

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Generate API REST from any SQL DataBase
 - `GET /` on the router lists all registered routes for quick discovery.
 - Each table additionally exposes `GET /<table>/meta` returning its JSON schema and converted `columns`.
 - Configure which tables and methods are exposed and alias table names as needed.
+- Add custom endpoints through the `customEndpoints` option passed to `routesObject`.
 - Customize generated JSON schema, relations and columns via hooks in `generateModels`.
 - Utility helpers cover status codes, data formatting, encryption/token helpers and email sending.
 - Create SQL dump files of your database via `dumpDatabase`.
@@ -71,6 +72,23 @@ const startServer = async () => {
 
 startServer().catch(err => console.error(err));
 ```
+
+## Adding custom endpoints
+
+`routesObject` accepts a `customEndpoints` option where you can define arbitrary routes bound to your controllers. The object keys are base paths and each contains HTTP method/path strings mapped to `ControllerName.action`.
+
+```ts
+const customRoutes = routesObject(models, controllers, {
+  customEndpoints: {
+    custom: {
+      'GET /': 'testController.customAction',
+      'PUT /:id': 'testController.updateAction'
+    }
+  }
+});
+```
+
+The above configuration generates `/custom/` and `/custom/:id` endpoints and they will appear in the root route list like any other service.
 
 ## Customizing generated models
 

--- a/__tests__/express-router.test.ts
+++ b/__tests__/express-router.test.ts
@@ -163,4 +163,22 @@ describe('routesObject function', () => {
     }));
   });
 
+  it('should include custom endpoints', () => {
+    const cfg: IExpressRouterConf = {
+      customEndpoints: {
+        custom: {
+          'GET /': 'testController.customAction',
+          'PUT /:id': 'testController.updateAction'
+        }
+      }
+    };
+
+    const result: IRoutesObject = routesObject(models, mockControllers, cfg);
+
+    expect(result).toEqual(expect.objectContaining<Partial<IRoutesObject>>({
+      'GET /custom/': ['GET', '/custom/', 'customAction', TestController, Model],
+      'PUT /custom/:id': ['PUT', '/custom/:id', 'updateAction', TestController, Model]
+    }));
+  });
+
 });

--- a/src/express-router.ts
+++ b/src/express-router.ts
@@ -19,6 +19,7 @@ import type {
   IRoutesObject,
   IStatusCode,
   IRouterMethods,
+  ICustomEndpoints,
 } from "./types";
 import GenericController from "./controller";
 import Controller from "./controller";
@@ -219,6 +220,29 @@ export function routesObject(
   } else {
     Object.values(models).forEach((TheModel) => {
       prepareRoutesObj(routesObj, TheModel, controllers, true);
+    });
+  }
+
+  if (config.customEndpoints) {
+    Object.entries(config.customEndpoints).forEach(([basePath, endpoints]) => {
+      const cleanBase = basePath.replace(/^\/+|\/+$/g, "");
+      Object.entries(endpoints as Record<string, string>).forEach(
+        ([service, handler]) => {
+          const [controllerName, action] = handler.split(".");
+          const TheController = controllers[controllerName];
+          if (!TheController) return;
+          const [m, p] = service.split(" ");
+          const method = m.toUpperCase() as IRoutesObject[1][0];
+          const servicePath = `/${cleanBase}${p}`;
+          routesObj[`${method} ${servicePath}`] = [
+            method,
+            servicePath,
+            action,
+            TheController,
+            Model,
+          ];
+        }
+      );
     });
   }
   return routesObj;

--- a/src/types.ts
+++ b/src/types.ts
@@ -81,8 +81,11 @@ export interface IFilterConf
   extends IBaseConfFilters,
     Record<string, string | boolean | IRouteConf> {}
 
+export type ICustomEndpoints = Record<string, Record<string, string>>;
+
 export type IExpressRouterConf = {
   filters?: IFilterConf;
+  customEndpoints?: ICustomEndpoints;
 };
 
 export type ISearch = {


### PR DESCRIPTION
## Summary
- extend `IExpressRouterConf` with `customEndpoints`
- generate routes for custom endpoints in `routesObject`
- test new custom endpoint functionality
- document `customEndpoints` in README

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_686ffddee3d883268369006bb4848057