### PR TITLE
Improve docs with Typedoc, translation and tests

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -3,7 +3,7 @@
     "@babel/preset-env",
     {
       "targets": {
-        "node": "current" // Asegúrate de apuntar a la versión node que estás usando
+        "node": "current"
       }
     }
   ]

--- a/__tests__/crypt.test.ts
+++ b/__tests__/crypt.test.ts
@@ -1,0 +1,35 @@
+import { encrypt, decrypt, generateCode, buildToken, readToken, generatePasswordHash, verifyPasswordHash, getClientType } from '../src/crypt';
+
+describe('crypt utilities', () => {
+  test('encrypt/decrypt round trip', () => {
+    const { encryptedData, iv } = encrypt('hello', 'pass', '');
+    const plain = decrypt(encryptedData, 'pass', iv);
+    expect(plain).toBe('hello');
+  });
+
+  test('generateCode creates 6 digit codes', () => {
+    const code = generateCode();
+    expect(code).toMatch(/^\d{6}$/);
+  });
+
+  test('password hashing and verification', async () => {
+    const hash = await generatePasswordHash('secret');
+    expect(typeof hash).toBe('string');
+    const ok = await verifyPasswordHash('secret', hash as string);
+    expect(ok).toBe(true);
+    const bad = await verifyPasswordHash('wrong', hash as string);
+    expect(bad).toBe(false);
+  });
+
+  test('buildToken/readToken round trip', () => {
+    const { iv } = encrypt('x', 'pass', '');
+    const token = buildToken({ payload: { foo: 'bar' } }, 'pass', iv, '1h');
+    const data = readToken(token, 'pass', iv);
+    expect((data as any).payload.foo).toBe('bar');
+  });
+
+  test('getClientType parses user agent', () => {
+    const type = getClientType('Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/115.0.0.0 Safari/537.36');
+    expect(type).toBe('Chrome');
+  });
+});

--- a/src/auth-controller.mjs
+++ b/src/auth-controller.mjs
@@ -140,7 +140,7 @@ class AuthController extends MongooseController {
     labelSufix = 'SESSION',
     iv
   } = {}) {
-    //crear nueva sesión
+    //create new session
     const ipReal = req.get('x-forwarded-for') ? req.get('x-forwarded-for').split(',')[0].trim() : req.socket.remoteAddress;
     const ip = ipReal === '::1' ? process.env.HARDCODED_IP : ipReal;
     const sessionName = uuidv4();
@@ -428,7 +428,7 @@ class AuthController extends MongooseController {
       if (verifyPass instanceof Error) throw verifyPass;
       if (!verifyPass) throw new Error('PassError');
       status = 200;
-      //tres meses o 4 horas
+      //three months or four hours
       const expireSecs = rememberme ? 7776000 : 43200;
       const session = await this.createSession(user, { req, expireSecs, times: -1, labelSufix: 'SESSION', iv: group.iv });
       user.sessions.push(session._id);
@@ -452,7 +452,7 @@ class AuthController extends MongooseController {
         toReturn.message = error.message;
       }
     }
-    //TODO: crear sesion y tomar en cuenta rememberme
+    //TODO: create session and respect rememberme
     return this.r(status, code, 'login', toReturn);
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,13 @@ import * as pkg from './index';
 
 const cli = yargs(hideBin(process.argv));
 
+/**
+ * Parse a CLI argument. If the argument is a path to a JSON file, the file is
+ * loaded and JSON references are resolved. Otherwise the raw value is returned.
+ *
+ * @param value - Raw argument value.
+ * @returns Parsed value.
+ */
 function parseInput(value: string): any {
   if (typeof value !== 'string') return value;
   let content = value;
@@ -39,7 +46,7 @@ for (const name of Object.keys(pkg)) {
   } else {
     cli.command(
       name + ' [args..]',
-      `Ejecuta la función ${name}`,
+      `Run the function ${name}`,
       y => y.positional('args', { type: 'string', array: true }),
       async argv => {
         const raw = (argv.args || []) as any[];

--- a/src/crypt.ts
+++ b/src/crypt.ts
@@ -3,7 +3,18 @@ import jwt from "jsonwebtoken";
 import bcrypt from 'bcrypt';
 import useragent from 'useragent';
 
-
+/**
+ * Encrypt a string using AES-256-CBC.
+ *
+ * @param text - Plain text to encrypt.
+ * @param password - Password used for key derivation.
+ * @param ivString - Initialization vector in hex format.
+ * @returns Object containing encrypted data and IV.
+ *
+ * @example
+ * const { encryptedData, iv } = encrypt('hello', 'pass', '');
+ * const plain = decrypt(encryptedData, 'pass', iv);
+ */
 export function encrypt(text: string, password: string, ivString: string) {
   const iv = ivString ? Buffer.from(ivString, 'hex') : crypto.randomBytes(16);
   const key = crypto.scryptSync(password, 'salt', 32);
@@ -13,6 +24,14 @@ export function encrypt(text: string, password: string, ivString: string) {
   return { encryptedData: encrypted, iv: iv.toString('hex') };
 }
 
+/**
+ * Decrypt data encrypted with {@link encrypt}.
+ *
+ * @param encryptedData - The hexadecimal encrypted string.
+ * @param password - Password used for key derivation.
+ * @param ivString - Initialization vector in hex format.
+ * @returns The decrypted plain text.
+ */
 export function decrypt(encryptedData: string, password: string, ivString: string) {
   const key = crypto.scryptSync(password, 'salt', 32);
   const decipher = crypto.createDecipheriv('aes-256-cbc', key, Buffer.from(ivString, 'hex'));
@@ -24,7 +43,12 @@ export function decrypt(encryptedData: string, password: string, ivString: strin
 
 /**
  * Generates a unique 6-digit code.
- * @returns {string} A 6-digit unique code.
+ *
+ * @returns A 6-digit code as string.
+ *
+ * @example
+ * const code = generateCode();
+ * console.log(code); // "482901"
  */
 export function generateCode() {
   const bytes = crypto.randomBytes(4);
@@ -46,13 +70,16 @@ const generateKeyFromInput = (input: string) => {
 };
 
 /**
- * Build a secure token
- * 
- * @param {Object} data - The payload data
- * @param {string} pass - The encryption key
- * @param {string} ivString - ivString
- * @param {number|string} expiresIn - The expiration time for the token
- * @returns {string} - Returns the URL-safe encrypted token
+ * Build a secure token that contains encrypted data.
+ *
+ * @param data - Payload to include in the token.
+ * @param pass - Encryption key.
+ * @param ivString - Initialization vector in hex format.
+ * @param expiresIn - Expiration time for the JWT.
+ * @returns URL-safe encrypted token string.
+ *
+ * @example
+ * const token = buildToken({ payload: { foo: 'bar' } }, 'pass', iv, '1h');
  */
 export const buildToken = (data: { payload: any }, pass: string, ivString: string, expiresIn: string) => {
   // Encrypt the JSON content
@@ -69,11 +96,12 @@ export const buildToken = (data: { payload: any }, pass: string, ivString: strin
 }
 
 /**
- * Decrypt a secure token to get the payload data
- * @param {string} encryptedToken - The encrypted token
- * @param {string} pass - The decryption key
- * @param {string} ivString - ivString
- * @returns {Object|null} - Returns the decrypted payload data, or null if decryption fails
+ * Decrypt a token created with {@link buildToken}.
+ *
+ * @param encryptedToken - The encrypted token.
+ * @param pass - Decryption key.
+ * @param ivString - Initialization vector in hex format.
+ * @returns The decrypted payload or an Error instance.
  */
 export const readToken = (encryptedToken: string, pass: string, ivString: string) => {
   try {
@@ -102,6 +130,15 @@ export const readToken = (encryptedToken: string, pass: string, ivString: string
   }
 };
 
+/**
+ * Generate a bcrypt hash from a plain password.
+ *
+ * @param password - Password to hash.
+ * @returns The hashed password or an Error.
+ *
+ * @example
+ * const hash = await generatePasswordHash('secret');
+ */
 export async function generatePasswordHash(password: string) {
   try {
     const saltRounds = 10;
@@ -112,6 +149,13 @@ export async function generatePasswordHash(password: string) {
   }
 }
 
+/**
+ * Verify a password against a bcrypt hash.
+ *
+ * @param password - Plain password to verify.
+ * @param hash - Previously generated hash.
+ * @returns True if the password matches, otherwise false or an Error.
+ */
 export async function verifyPasswordHash(password: string, hash: string) {
   try {
     const isMatch = await bcrypt.compare(password, hash);
@@ -121,6 +165,13 @@ export async function verifyPasswordHash(password: string, hash: string) {
   }
 }
 
+/**
+ * Determine the client family from a user-agent string.
+ *
+ * @param userAgent - Raw user-agent header string.
+ * @param device - Optional device hint.
+ * @returns The detected client family (e.g. 'Chrome').
+ */
 export function getClientType(userAgent: string, device?: string) {
   const agent = useragent.parse(userAgent);
   return agent.family;

--- a/src/email.ts
+++ b/src/email.ts
@@ -163,10 +163,10 @@ export const enqueueEmailList = async (transportConf: Partial<Transporter>) => {
       const transporter = nodemailer.createTransport(transportConf);
       transporter.verify((error, success) => {
         if (error) {
-          console.error('Error al conectar con el servidor SMTP:', error);
+          console.error('Error connecting to the SMTP server:', error);
           reject(error);
         } else {
-          console.log('Servidor está listo para enviar correos:', success);
+          console.log('Server is ready to send emails:', success);
           resolve(transporter);
         }
       });

--- a/src/model-utilities.ts
+++ b/src/model-utilities.ts
@@ -1,6 +1,16 @@
 import { pascalCase } from "change-case-all";
 import { Model, JSONSchema } from "objection";
 
+/**
+ * Retrieve an Objection model by its table name.
+ *
+ * @param tableName - Name of the table to search for.
+ * @param models - Object containing available models.
+ * @returns The matching model or undefined.
+ *
+ * @example
+ * const User = getModelByTableName("users", allModels);
+ */
 export function getModelByTableName(tableName: string, models: Record<string, typeof Model>) {
   return Object.values(models).find(
     (ModelIn) => ModelIn.tableName === tableName


### PR DESCRIPTION
## Summary
- translate spanish log messages and comments into English
- document helper functions using Typedoc comments
- add docs for CLI input parsing
- add docs for retrieving models by table name
- add extensive docs for crypt helpers
- test crypt helpers
- remove AI-style instructions from babel config

## Testing
- `yarn test`


------
https://chatgpt.com/codex/tasks/task_e_6876b4f5ac288326904d87779738d449