### PR TITLE
Add formatData docs and tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -130,6 +130,21 @@ CLI tools (`mysqldump`, `pg_dump` or `sqlite3`) being available.
 await dumpDatabase(knexInstance, './dumps');
 // => { schemaFile: './dumps/schema.sql', fullFile: './dumps/schema_data.sql' }
 ```
+## Data formatting
+
+Use `formatData` to transform objects based on simple rules. Add custom rule handlers with `addRuleActions`.
+
+```ts
+import { formatData, addRuleActions } from "adba";
+
+addRuleActions({
+  ":upper": (v) => String(v).toUpperCase(),
+});
+
+const res = formatData({ name: "john", age: 30 }, { name: ["string", ":upper"], age: "number" });
+// res => { name: "JOHN", age: 30 }
+```
+
 
 ## Meta endpoints
 

--- a/__tests__/format-data.test.ts
+++ b/__tests__/format-data.test.ts
@@ -1,0 +1,32 @@
+import formatData, { addRuleActions } from '../src/format-data';
+
+describe('formatData utility', () => {
+  test('converts number to string', () => {
+    const data = { val: 5 };
+    const rules = { val: 'string' } as any;
+    expect(formatData(data, rules)).toEqual({ val: '5' });
+  });
+
+  test('joins array values', () => {
+    const data = { tags: ['a', 'b'] };
+    const rules = { tags: ['array', ':join'] } as any;
+    expect(formatData(data, rules)).toEqual({ tags: 'a,b' });
+  });
+
+  test('supports custom rule actions', () => {
+    addRuleActions({
+      ':upper': (v: string) => v.toUpperCase(),
+    });
+    const data = { name: 'john' };
+    const rules = { name: ['string', ':upper'] } as any;
+    expect(formatData(data, rules)).toEqual({ name: 'JOHN' });
+  });
+
+  test('uses replace function', () => {
+    const data = { a: 1, b: 2 };
+    const rules = {
+      a: [':replace', undefined, (_k: string, val: number, src: any) => val + src.b],
+    } as any;
+    expect(formatData(data, rules)).toEqual({ a: 3 });
+  });
+});

--- a/src/format-data.ts
+++ b/src/format-data.ts
@@ -1,14 +1,21 @@
+/**
+ * Utility helpers to transform plain objects based on declarative rules.
+ * Register custom rule handlers using {@link addRuleActions} and apply them via {@link formatData}.
+ */
 import moment from 'moment';
 import type { IExtraRules, IRuleAction, IRuleArray, IRules } from './types';
 
-/** 
- * Stores additional custom rules that can be added dynamically 
+/**
+ * Registry of user-provided rule handlers keyed by rule name.
+ * Populated via {@link addRuleActions}.
  */
 const extraRules: IExtraRules = {};
 
 /**
  * Adds more rule actions to the `extraRules` object.
  * @param moreRules - An object containing rules to be added.
+ * @example
+ * addRuleActions({ ':upper': (v) => String(v).toUpperCase() })
  */
 export function addRuleActions(moreRules: IExtraRules) {
   // Merge existing rules with new ones
@@ -63,6 +70,9 @@ function ruleActionReplace(ruleIn: boolean | IRuleAction, value: any, defaultFun
  * @param data - The object where keys are field names and values are the data to format.
  * @param rules - The object containing rules to use for formatting.
  * @returns Returns a new object with formatted values.
+ * @example
+ * const result = formatData({ name: 'john' }, { name: ['string', ':upper'] })
+ * // => { name: 'JOHN' }
  */
 export default function formatData(data: { [key: string]: any }, rules: IRules) {
   const toReturn = Object.entries(data).reduce((r: { [key: string]: any }, [key, value]) => {


### PR DESCRIPTION
## Summary
- document formatData module and add examples
- mention data formatting in README
- cover formatData with unit tests

## Testing
- `yarn test`

------
https://chatgpt.com/codex/tasks/task_e_688252d091e88326b7b364d9bd978e0a