### PR TITLE
Add unit tests for utils

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ Generate API REST from any SQL DataBase
 
 - test on PostgreSQL
 - test on MSSQL
+- [ ] Implement integration tests for PostgreSQL database (see postgres-connection.test.ts)
+- [ ] Implement integration tests for MSSQL database (see mssql-connection.test.ts)
 
 ## Example
 

--- a/__tests__/db-type-mapping.test.ts
+++ b/__tests__/db-type-mapping.test.ts
@@ -1,0 +1,38 @@
+import {
+  mapSqliteTypeToJsonType,
+  mapSqliteTypeToJsonFormat,
+} from '../src/generate-sqlite-models';
+import {
+  mapMySqlTypeToJsonType,
+  mapMySqlTypeToJsonFormat,
+} from '../src/generate-mysql-models';
+import {
+  mapPostgresTypeToJsonType,
+  mapPostgresTypeToJsonFormat,
+} from '../src/generate-postgresql-models';
+import {
+  mapMssqlTypeToJsonType,
+  mapMssqlTypeToJsonFormat,
+} from '../src/generate-mssql-models';
+
+describe('DB type mapping utilities', () => {
+  test('sqlite type mapping', () => {
+    expect(mapSqliteTypeToJsonType('INTEGER')).toBe('integer');
+    expect(mapSqliteTypeToJsonFormat('DATETIME', 'col')).toBe('datetime');
+  });
+
+  test('mysql type mapping', () => {
+    expect(mapMySqlTypeToJsonType('VARCHAR')).toBe('string');
+    expect(mapMySqlTypeToJsonFormat('DATE', 'd')).toBe('date');
+  });
+
+  test('postgres type mapping', () => {
+    expect(mapPostgresTypeToJsonType('BYTEA')).toBe('buffer');
+    expect(mapPostgresTypeToJsonFormat('TIME', 't')).toBe('time');
+  });
+
+  test('mssql type mapping', () => {
+    expect(mapMssqlTypeToJsonType('INT')).toBe('integer');
+    expect(mapMssqlTypeToJsonFormat('DATE', 'd')).toBe('date');
+  });
+});

--- a/__tests__/generate-models-switch.test.ts
+++ b/__tests__/generate-models-switch.test.ts
@@ -1,0 +1,59 @@
+import { generateModels } from '../src/generate-models';
+import { generateSQLiteModels } from '../src/generate-sqlite-models';
+import { generatePostgreSQLModels } from '../src/generate-postgresql-models';
+import { generateMySQLModels } from '../src/generate-mysql-models';
+import { generateMSSQLModels } from '../src/generate-mssql-models';
+
+jest.mock('../src/generate-sqlite-models');
+jest.mock('../src/generate-postgresql-models');
+jest.mock('../src/generate-mysql-models');
+jest.mock('../src/generate-mssql-models');
+
+const mockedSQLite = generateSQLiteModels as jest.Mock;
+const mockedPg = generatePostgreSQLModels as jest.Mock;
+const mockedMysql = generateMySQLModels as jest.Mock;
+const mockedMssql = generateMSSQLModels as jest.Mock;
+
+beforeEach(() => {
+  mockedSQLite.mockResolvedValue({ sqlite: true });
+  mockedPg.mockResolvedValue({ pg: true });
+  mockedMysql.mockResolvedValue({ mysql: true });
+  mockedMssql.mockResolvedValue({ mssql: true });
+});
+
+describe('generateModels database switch', () => {
+  const knex: any = { client: { config: { client: '' } } };
+
+  it('uses sqlite generator', async () => {
+    knex.client.config.client = 'sqlite';
+    const res = await generateModels(knex);
+    expect(mockedSQLite).toHaveBeenCalledWith(knex, {});
+    expect(res).toEqual({ sqlite: true });
+  });
+
+  it('uses postgres generator', async () => {
+    knex.client.config.client = 'pg';
+    const res = await generateModels(knex);
+    expect(mockedPg).toHaveBeenCalledWith(knex, {});
+    expect(res).toEqual({ pg: true });
+  });
+
+  it('uses mysql generator', async () => {
+    knex.client.config.client = 'mysql2';
+    const res = await generateModels(knex);
+    expect(mockedMysql).toHaveBeenCalledWith(knex, {});
+    expect(res).toEqual({ mysql: true });
+  });
+
+  it('uses mssql generator', async () => {
+    knex.client.config.client = 'mssql';
+    const res = await generateModels(knex);
+    expect(mockedMssql).toHaveBeenCalledWith(knex, {});
+    expect(res).toEqual({ mssql: true });
+  });
+
+  it('throws on unsupported client', async () => {
+    knex.client.config.client = 'oracle';
+    await expect(generateModels(knex)).rejects.toThrow('Unsupported database client: oracle');
+  });
+});

--- a/__tests__/mssql-connection.test.ts
+++ b/__tests__/mssql-connection.test.ts
@@ -1,0 +1,3 @@
+// TODO: Implement integration tests for MSSQL database
+// Setup a temporary MSSQL instance and verify model generation
+it.todo('generates models from MSSQL database');

--- a/__tests__/postgres-connection.test.ts
+++ b/__tests__/postgres-connection.test.ts
@@ -1,0 +1,3 @@
+// TODO: Implement integration tests for PostgreSQL database
+// Setup a temporary PostgreSQL instance and verify model generation
+it.todo('generates models from PostgreSQL database');

--- a/__tests__/route-utils.test.ts
+++ b/__tests__/route-utils.test.ts
@@ -1,0 +1,35 @@
+import express from 'express';
+import expressRouter, { routesObject, addTableAlias, modifyDefinedRoutes, listRoutes } from '../src/express-router';
+import Controller from '../src/controller';
+import { Model } from 'objection';
+
+describe('express router helpers', () => {
+  class TestModel extends Model { static tableName = 'util_table'; }
+  class TestController extends Controller { constructor(){ super(TestModel);} }
+  const models = { TestModel };
+  const controllers = { TestController } as any;
+
+  afterEach(() => {
+    // clean added routes and alias
+    modifyDefinedRoutes(['GET /extra'], true);
+    addTableAlias({ util_table: 'util-table' }); // reset alias to same name
+  });
+
+  it('modifyDefinedRoutes adds and removes routes', () => {
+    modifyDefinedRoutes({ 'GET /extra': 'list' });
+    const ro = routesObject(models, { testCtrl: TestController } as any, {});
+    expect(ro).toHaveProperty('GET /util-table/extra');
+    modifyDefinedRoutes(['GET /extra'], true);
+    const ro2 = routesObject(models, { testCtrl: TestController } as any, {});
+    expect(ro2).not.toHaveProperty('GET /util-table/extra');
+  });
+
+  it('listRoutes retrieves router paths', () => {
+    const ro = routesObject(models, { testCtrl: TestController } as any, {});
+    const router = express.Router();
+    const configured = expressRouter(ro, { router });
+    const list = listRoutes(configured);
+    expect(list).toContain('GET /');
+    expect(list.some(r=>r.includes('/util-table/'))).toBe(true);
+  });
+});

--- a/__tests__/status-codes.test.ts
+++ b/__tests__/status-codes.test.ts
@@ -1,0 +1,28 @@
+import getStatusCode, { addStatusCodes } from '../src/status-codes';
+
+describe('status code utilities', () => {
+  it('returns exact code when available', () => {
+    const sc = getStatusCode(200);
+    expect(sc.status).toBe(200);
+  });
+
+  it('returns added custom status', () => {
+    addStatusCodes([{ status: 201, code: 1, description: 'created-alt', error: false, success: true }]);
+    const sc = getStatusCode(201, 1);
+    expect(sc.description).toBe('created-alt');
+  });
+
+  it('falls back to group code', () => {
+    const sc = getStatusCode(250);
+    expect(sc.status).toBe(200);
+  });
+
+  it('returns unknown error when no match', () => {
+    const sc = getStatusCode(999);
+    expect(sc.description).toBe('unknown-error');
+  });
+
+  it('throws when adding invalid code', () => {
+    expect(() => addStatusCodes([{ code: 1 } as any])).toThrow('missing status');
+  });
+});


### PR DESCRIPTION
## Summary
- add tests for status code mapping
- test express router helpers
- check database type mapping functions
- add generateModels switch test
- create skeleton tests for PostgreSQL & MSSQL
- document pending tests in TODO section

## Testing
- `yarn test --coverage`

------
https://chatgpt.com/codex/tasks/task_e_688a684ee5c08326bca64b3cbc259996