### PR TITLE
docs: document multi-column ordering and add tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Generate API REST from any SQL DataBase
 - Configure which tables and methods are exposed and alias table names as needed.
 - Add custom endpoints through the `customEndpoints` option passed to `routesObject`.
 - Customize generated JSON schema, relations and columns via hooks in `generateModels`.
+- Apply multi-column ordering to queries using the controller's `orderBy` support.
 - Utility helpers cover status codes, data formatting, encryption/token helpers and email sending.
 - Create SQL dump files of your database via `dumpDatabase`.
 

--- a/__tests__/apply-ordering.test.ts
+++ b/__tests__/apply-ordering.test.ts
@@ -1,0 +1,35 @@
+import Knex from 'knex';
+import { Model } from 'objection';
+
+import Controller from '../src/controller';
+
+describe('applyOrderByLite', () => {
+  let knexInstance: ReturnType<typeof Knex>;
+
+  class SampleModel extends Model {
+    static tableName = 'users';
+  }
+
+  beforeAll(() => {
+    knexInstance = Knex({ client: 'sqlite3', useNullAsDefault: true });
+    Model.knex(knexInstance);
+  });
+
+  afterAll(async () => {
+    await knexInstance.destroy();
+  });
+
+  test('builds correct SQL for multiple orderings', () => {
+    const controller = new Controller(SampleModel);
+    const query = SampleModel.query();
+    controller.applyOrderByLite(query, {
+      created_at: 'desc',
+      'profile.name': 'asc',
+      id: 'invalid',
+    });
+    const sql = query.toKnexQuery().toSQL().sql;
+    expect(sql).toBe(
+      'select `users`.* from `users` order by `users`.`created_at` desc, `profile`.`name` asc, `users`.`id` asc'
+    );
+  });
+});

--- a/src/controller.ts
+++ b/src/controller.ts
@@ -198,12 +198,26 @@ export default class Controller {
   }
 
   /**
-   * Apply multi column ordering to an Objection/Knex query.
-   * Accepts an object like: { "created_at": "desc", "user.name": "asc" }
+   * Applies multi-column ordering to an Objection or Knex query builder.
    *
-   * - Dotted paths (e.g. "user.name") se pasan tal cual (debes haber hecho joinRelated/withGraphJoined).
-   * - Columnas sin punto se cualifican con ModelInUse.tableName.
-   * - Cualquier dir inválida cae a "asc".
+   * Accepts an object like `{ created_at: 'desc', 'user.name': 'asc' }`.
+   *
+   * - Dotted paths (e.g. `user.name`) are used as provided. Ensure related
+   *   tables have been joined via `joinRelated` or `withGraphJoined`.
+   * - Columns without a dot are qualified with the model table name.
+   * - Any invalid direction defaults to `'asc'`.
+   *
+   * @param queryBuilderIn - Query builder instance to apply ordering to.
+   * @param orderBy - Mapping of column paths to sort direction.
+   *
+   * @example
+   * ```ts
+   * const query = SampleModel.query();
+   * controller.applyOrderByLite(query, {
+   *   created_at: 'desc',
+   *   'profile.name': 'asc'
+   * });
+   * ```
    */
   applyOrderByLite(
     queryBuilderIn: any, // QueryBuilder


### PR DESCRIPTION
## Summary
- document multi-column ordering helper and provide usage example
- cover multi-column ordering with a unit test verifying generated SQL
- note multi-column order-by support in project README

## Testing
- `npx jest __tests__/apply-ordering.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_689dfd1868308326a7e9ca6da6daf112

## Summary by Sourcery

Document the controller's multi-column ordering helper with detailed JSDoc and README entry, and add a unit test to verify its generated SQL.

Enhancements:
- Expand JSDoc for applyOrderByLite to detail usage, parameter descriptions, and examples

Documentation:
- Add README entry noting multi-column ordering support via controller's orderBy helper

Tests:
- Add unit test for multi-column ordering verifying the generated SQL